### PR TITLE
Update PageID boolean status

### DIFF
--- a/packages/statuspage.io/src/Statuspage.ts
+++ b/packages/statuspage.io/src/Statuspage.ts
@@ -11,7 +11,7 @@ export class Statuspage {
   private readonly apiClient: AxiosInstance;
 
   constructor(pageId: string) {
-    if (pageId) {
+    if (!pageId) {
       throw new Error('A page ID needs to be set in order to use the client.');
     }
 


### PR DESCRIPTION
Currently you'll always get an error that the Page ID needs to be set even if you actually specify a Page ID. Now, an error will only display when the Page ID is missing.