### PR TITLE
fix(statuspage.io): remove reference to node url lib to make it browser-compatible

### DIFF
--- a/packages/statuspage.io/src/Statuspage.ts
+++ b/packages/statuspage.io/src/Statuspage.ts
@@ -1,5 +1,4 @@
 import axios, {AxiosInstance} from 'axios';
-import {URL} from 'url';
 
 import {IncidentsAPI, ScheduledMaintenancesAPI, SubscribersAPI} from './api';
 import {Endpoint} from './Endpoints';
@@ -15,10 +14,8 @@ export class Statuspage {
       throw new Error('A page ID needs to be set in order to use the client.');
     }
 
-    const apiUrl = new URL(`https://${pageId}.statuspage.io`);
-
     this.apiClient = axios.create({
-      baseURL: apiUrl.href,
+      baseURL: `https://${pageId}.statuspage.io`,
     });
 
     this.api = {


### PR DESCRIPTION
Hello!
I've started using the statuspage package and quickly discovered that it's not working in a browser. I think the main purpose was to make it work in Node.js environment. I really like it so far and would like to use it in my project. After digging into the code I see that the problem that makes it incompatible with the browser is tiny. Simply the usage of the `url` library breaks the code in the browser. I'd suggest to stop using the `url` package in `statuspage` and specifying baseURL for Axios directly. Please take a look at my solution, would be great to get it merged and released, so I can use it in my project.

I have tested it in my app, so I can confirm that after this change it works in a browser.

Thanks!