### PR TITLE
fix wrong property name

### DIFF
--- a/packages/icanhazdadjoke/src/ICanHazDadJokeAPI.ts
+++ b/packages/icanhazdadjoke/src/ICanHazDadJokeAPI.ts
@@ -80,7 +80,7 @@ export class ICanHazDadJokeAPI {
     }
 
     const {data} = await this.apiClient.get<JokeSearchResult>('/search', {
-      data: options,
+      params: options,
     });
 
     return data;


### PR DESCRIPTION
Hi there!
Thank you for making this api client for icanhazdadjoke.com, it has really made my life a lot easier.

I discovered this bug some time ago where the search terms seem to be ignored when using `icanhazdadjoke.api.search()`.
The cause of this is pretty simple: you used a wrong property name due to some confusing stuff.
A GET request can have a _body_ (like POST and PUT), but it is ignored by the server.
What you were trying to do is specify _parameters_.
I looked it up and fixed it, and kind of tested locally (I required axios and checked the difference between `data` and `params`).

Have a nice day!