### PR TITLE
ScheduledMaintenances in Summary

### DIFF
--- a/packages/statuspage.io/src/interfaces/Result.ts
+++ b/packages/statuspage.io/src/interfaces/Result.ts
@@ -116,4 +116,4 @@ export interface Status extends Page {
 
 export type CombinedSubscriber = PhoneSubscriber | EmailSubscriber | WebhookSubscriber;
 
-export type Summary = Status & ScheduledMaintenance & Components & Incidents;
+export type Summary = Status & ScheduledMaintenances & Components & Incidents;


### PR DESCRIPTION
The summary API returns a list of schedules maintenances, so use ScheduledMaintenances to reflect that.
Can you make a new build with this change, so I can use it?